### PR TITLE
Opencode/stellar engine

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,11 +25,9 @@ jobs:
           node-version: "20"
           cache: "pnpm"
       - run: pnpm install
-      - run: pnpm build:web
-      - name: Add CNAME
-        run: echo "thuis.aldof.duckdns.org" > packages/web-app/dist/CNAME
+      - run: pnpm --filter website build
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: packages/web-app/dist
+          path: website/build
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -8,7 +8,7 @@ export default function Home() {
         <h1>Thuis-V2 Documentation</h1>
         <p>Welcome to the Thuis-V2 documentation portal.</p>
         <p>
-          <a href="/thuis/docs/intro" style={{ fontSize: '1.2rem', margin: '0 1rem' }}>
+          <a href="/thuis/intro" style={{ fontSize: '1.2rem', margin: '0 1rem' }}>
             Get Started
           </a>
           <a href="https://github.com/Aldo-f/thuis" style={{ fontSize: '1.2rem', margin: '0 1rem' }}>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch GitHub Pages to deploy the Docusaurus docs (`website`) and fix the homepage "Get Started" link. This ensures aldo-f.github.io/thuis serves the docs and the intro link works.

- **Bug Fixes**
  - CI: Build and deploy the `website` Docusaurus site with `pnpm --filter website build`; upload `website/build`. Removed web-app build and CNAME step.
  - Docs: Update home link to `/thuis/intro` to match `routeBasePath: '/'`.

<sup>Written for commit b647902e33ee943489fc554bda1727b532d88c2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Aldo-f/thuis/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

